### PR TITLE
fix version func

### DIFF
--- a/modfile.go
+++ b/modfile.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"golang.org/x/mod/modfile"
+	mod "golang.org/x/mod/module"
 )
 
 func isRelativePath(path string) bool { return strings.HasPrefix(path, ".") }
@@ -16,11 +17,29 @@ func modFile(dir string) (*modfile.File, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read go.mod file: %w", err)
 	}
-	f, err := modfile.Parse("go.mod", b, func(path, vers string) (string, error) {
-		return "v0.0.1", nil // fake valid version to tolerate un-tidy files
-	})
+	f, err := modfile.Parse("go.mod", b, fixVersion)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse go.mod file: %w", err)
 	}
 	return f, nil
+}
+
+// fake valid version to tolerate un-tidy files
+func fixVersion(path, vers string) (string, error) {
+	_, pathMajor, pathMajorOk := mod.SplitPathVersion(path)
+	if vers == "" || vers != mod.CanonicalVersion(vers) {
+		if pathMajor == "" {
+			return "v0.0.1", nil
+		}
+		return fmt.Sprintf("%s.0.2", mod.PathMajorPrefix(pathMajor)), nil
+	}
+	if pathMajorOk {
+		if err := mod.CheckPathMajor(vers, pathMajor); err != nil {
+			if pathMajor == "" {
+				return vers + "+incompatible", nil
+			}
+			return fmt.Sprintf("%s.0.3", mod.PathMajorPrefix(pathMajor)), nil
+		}
+	}
+	return vers, nil
 }


### PR DESCRIPTION
The version can't be faked with a constant value since the tool still validates the major version against the path.