### PR TITLE
add -live flag for streaming logs

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ var (
 	cmdSh     bool
 	force     bool
 	goCmd     bool
+	liveLogs  bool
 	skips     []string
 	unordered bool
 	verbose   bool
@@ -23,6 +24,7 @@ func initFlags() {
 	flag.BoolVar(&cmdSh, "c", false, "command: command string execution with 'sh -c' prefix")
 	flag.BoolVar(&force, "f", false, "force: continue execution even if dependencies failed")
 	flag.BoolVar(&goCmd, "go", false, "go: execute with 'go' prefix")
+	flag.BoolVar(&liveLogs, "live", false, "live: enable live logging")
 	//TODO -q (quiet)
 	skip := flag.String("s", "", "skip: comma separated list of paths to skip")
 	//TODO -p to limit parallelism?

--- a/module.go
+++ b/module.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,13 +17,13 @@ type module struct {
 	deps  []Dep
 	dones []<-chan struct{}
 
-	logs bytes.Buffer
+	logs *bytes.Buffer // optional
 }
 
 type result struct {
 	Dep
 
-	logs bytes.Buffer
+	logs *bytes.Buffer // optional
 
 	skipped bool
 	*command
@@ -32,7 +33,7 @@ type result struct {
 type command struct {
 	name string
 	//TODO separate err/out?
-	output bytes.Buffer
+	output bytes.Buffer // nil if liveLogs
 }
 
 func (m *module) newResult(err error) *result {
@@ -40,7 +41,11 @@ func (m *module) newResult(err error) *result {
 }
 
 func (m *module) logf(format string, a ...any) {
-	fmt.Fprintf(&m.logs, format, a...)
+	if m.logs != nil {
+		fmt.Fprintf(m.logs, format, a...)
+		return
+	}
+	logf(string(m.rel)+" | "+format, a...)
 }
 
 // listRelative populates m.mod and m.deps.
@@ -52,7 +57,7 @@ func (m *module) listRelative() error {
 	if mf.Module != nil {
 		m.mod = ModulePath(mf.Module.Mod.Path)
 		if verbose {
-			m.logf("%s/go.mod: module %s\n", m.rel, m.mod)
+			m.logf("module %s\n", m.mod)
 		}
 	}
 	for _, l := range mf.Replace {
@@ -134,10 +139,48 @@ func (m *module) execute(ctx context.Context, args []string) *result {
 	}
 	cmd.Dir = string(m.rel)
 	r.command = new(command)
-	cmd.Stdout = &r.output
-	cmd.Stderr = &r.output
+	if !liveLogs {
+		cmd.Stdout = &r.output
+		cmd.Stderr = &r.output
+	} else {
+		//TODO separate err/out prefixes?
+		p := &prefixer{prefix: string(m.rel) + " | ", w: os.Stderr}
+		cmd.Stdout = p
+		cmd.Stderr = p
+	}
 
 	r.name = strings.Join(cmd.Args, " ")
 	r.err = cmd.Run() //TODO why not just CombinedOutput?
 	return r
+}
+
+type prefixer struct {
+	w             io.Writer
+	prefix        string
+	buf           bytes.Buffer
+	newLineSuffix bool
+}
+
+func (p *prefixer) Write(bs []byte) (int, error) {
+	p.buf.Reset()
+	if p.newLineSuffix {
+		p.buf.WriteString(p.prefix)
+		p.newLineSuffix = false
+	}
+	for i, b := range bs {
+		p.buf.WriteByte(b)
+		if b == '\n' {
+			if i == len(bs)-1 {
+				p.newLineSuffix = true
+			} else {
+				p.buf.WriteString(p.prefix)
+			}
+		}
+	}
+	n64, err := p.buf.WriteTo(p.w)
+	if err != nil {
+		n := max(int(n64), len(bs))
+		return n, err
+	}
+	return len(bs), nil
 }

--- a/testdata/basic.txtar
+++ b/testdata/basic.txtar
@@ -88,13 +88,13 @@ found 3 go.mod files:
 	a/go.mod
 	a/c/go.mod
 	b/go.mod
-a/go.mod: module example.com/a
+module example.com/a
 	example.com/a/c => a/c
 	example.com/b => b
 a$ go mod tidy
-a/c/go.mod: module example.com/a/c
+module example.com/a/c
 a/c$ go mod tidy
-b/go.mod: module example.com/b
+module example.com/b
 	example.com/a/c => a/c
 b$ go mod tidy
 -- graph-out.txt --
@@ -138,12 +138,12 @@ found 3 go.mod files:
 	a/go.mod
 	a/c/go.mod
 	b/go.mod
-a/go.mod: module example.com/a
+module example.com/a
 	example.com/a/c => a/c
 	example.com/b => b
 a$ go mod graph
-a/c/go.mod: module example.com/a/c
+module example.com/a/c
 a/c$ go mod graph
-b/go.mod: module example.com/b
+module example.com/b
 	example.com/a/c => a/c
 b$ go mod graph

--- a/testdata/c.txtar
+++ b/testdata/c.txtar
@@ -88,13 +88,13 @@ found 3 go.mod files:
 	a/go.mod
 	a/c/go.mod
 	b/go.mod
-a/go.mod: module example.com/a
+module example.com/a
 	example.com/a/c => a/c
 	example.com/b => b
 a$ sh -c go mod tidy
-a/c/go.mod: module example.com/a/c
+module example.com/a/c
 a/c$ sh -c go mod tidy
-b/go.mod: module example.com/b
+module example.com/b
 	example.com/a/c => a/c
 b$ sh -c go mod tidy
 -- graph-out.txt --
@@ -138,12 +138,12 @@ found 3 go.mod files:
 	a/go.mod
 	a/c/go.mod
 	b/go.mod
-a/go.mod: module example.com/a
+module example.com/a
 	example.com/a/c => a/c
 	example.com/b => b
 a$ sh -c go mod graph
-a/c/go.mod: module example.com/a/c
+module example.com/a/c
 a/c$ sh -c go mod graph
-b/go.mod: module example.com/b
+module example.com/b
 	example.com/a/c => a/c
 b$ sh -c go mod graph

--- a/testdata/live.txtar
+++ b/testdata/live.txtar
@@ -1,0 +1,42 @@
+exec gomods -live -w cat fake-logs.txt
+cmp stdout out.txt
+cmp stderr err.txt
+
+exec gomods -live -v -w cat fake-logs.txt
+cmp stdout out-v.txt
+cmp stderr err-v.txt
+
+-- this/is/a/long/path/to/module/go.mod --
+module example.com/go-module
+
+go 1.21.3
+
+-- this/is/a/long/path/to/module/module.go --
+package module
+
+const Var = "test"
+
+-- out.txt --
+-- err.txt --
+found 1 go.mod files:
+	this/is/a/long/path/to/module/go.mod
+This is a log message
+this/is/a/long/path/to/module | This one is structured but human readable foo=42 err="something happened"
+this/is/a/long/path/to/module | {"msg":"This line is json", "foo":42, "err":"something happened"}
+this/is/a/long/path/to/module | What about very very very very very very very very very very very very very very very very very very very very very very very very long lines, or long woooooooooooooooooooorrrrrrrrrrrrrrrrrrrrrrrrrrdddddddddddddddddddddddddddddddssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss
+this/is/a/long/path/to/module$ cat fake-logs.txt
+-- out-v.txt --
+-- err-v.txt --
+found 1 go.mod files:
+	this/is/a/long/path/to/module/go.mod
+this/is/a/long/path/to/module | module example.com/go-module
+This is a log message
+this/is/a/long/path/to/module | This one is structured but human readable foo=42 err="something happened"
+this/is/a/long/path/to/module | {"msg":"This line is json", "foo":42, "err":"something happened"}
+this/is/a/long/path/to/module | What about very very very very very very very very very very very very very very very very very very very very very very very very long lines, or long woooooooooooooooooooorrrrrrrrrrrrrrrrrrrrrrrrrrdddddddddddddddddddddddddddddddssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss
+this/is/a/long/path/to/module$ cat fake-logs.txt
+-- this/is/a/long/path/to/module/fake-logs.txt --
+This is a log message
+This one is structured but human readable foo=42 err="something happened"
+{"msg":"This line is json", "foo":42, "err":"something happened"}
+What about very very very very very very very very very very very very very very very very very very very very very very very very long lines, or long woooooooooooooooooooorrrrrrrrrrrrrrrrrrrrrrrrrrdddddddddddddddddddddddddddddddssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss

--- a/testdata/scope.txtar
+++ b/testdata/scope.txtar
@@ -77,7 +77,7 @@ found 2 go.mod files:
 found 2 go.mod files:
 	./go.mod
 	c/go.mod
-./go.mod: module example.com/a
+module example.com/a
 	example.com/a/c => c
 	example.com/b => ../b
-c/go.mod: module example.com/a/c
+module example.com/a/c

--- a/testdata/skip.txtar
+++ b/testdata/skip.txtar
@@ -78,5 +78,5 @@ found 3 go.mod files:
 	b/go.mod
 a (skipped)
 a/c (skipped)
-b/go.mod: module example.com/b
+module example.com/b
 	example.com/a/c => a/c


### PR DESCRIPTION
This PR adds a `-live` flag for streaming log output. The format needs work, but I'd like to make this the default when it is ready.

Fixes #13